### PR TITLE
Feat: Add logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,27 @@ require('mago-nvim').setup()
 {
   'calvinludwig/mago.nvim',
   ft = 'php',  -- Load only for PHP files
-  opts = {},
+  opts = {
+    logging = {
+      notify = true,
+      write_to_log = false,
+      min_level = 'INFO',
+      log_file = nil,
+    },
+  },
+}
+```
+
+### Configuration
+
+```lua
+require('mago-nvim').setup {
+  logging = {
+    notify = true, -- show vim.notify for stderr messages
+    write_to_log = false, -- append filtered messages to a log file
+    min_level = 'INFO', -- TRACE | DEBUG | INFO | WARN | ERROR
+    log_file = nil, -- defaults to: vim.fn.stdpath('log') .. '/mago.nvim.log'
+  },
 }
 ```
 

--- a/lua/mago-nvim/executable.lua
+++ b/lua/mago-nvim/executable.lua
@@ -1,6 +1,69 @@
 local M = {}
 
 M.mago_path = nil
+M.config = {
+  logging = {
+    notify = true,
+    write_to_log = false,
+    log_file = nil,
+    min_level = vim.log.levels.INFO,
+  },
+}
+
+local function normalize_level(level, fallback)
+  if type(level) == 'number' then
+    return level
+  end
+
+  if type(level) ~= 'string' then
+    return fallback
+  end
+
+  local key = level:upper()
+  if key == 'WARNING' then
+    key = 'WARN'
+  elseif key == 'ERR' then
+    key = 'ERROR'
+  end
+
+  return vim.log.levels[key] or fallback
+end
+
+local function parse_stderr_level(message)
+  local token = message:match '^%s*[%[%({<]*([%a_]+)'
+  if token == nil then
+    return vim.log.levels.ERROR
+  end
+
+  return normalize_level(token, vim.log.levels.ERROR)
+end
+
+local function level_name(level)
+  for name, value in pairs(vim.log.levels) do
+    if value == level then
+      return name
+    end
+  end
+
+  return 'ERROR'
+end
+
+local function write_log(message, level)
+  if not M.config.logging.write_to_log then
+    return
+  end
+
+  local log_path = M.config.logging.log_file or (vim.fn.stdpath 'log' .. '/mago.nvim.log')
+  local line = string.format('%s [%s] %s', os.date '%Y-%m-%d %H:%M:%S', level_name(level), message)
+
+  pcall(vim.fn.writefile, { line }, log_path, 'a')
+end
+
+function M.setup(opts)
+  opts = opts or {}
+  M.config = vim.tbl_deep_extend('force', M.config, opts)
+  M.config.logging.min_level = normalize_level(M.config.logging.min_level, vim.log.levels.ERROR)
+end
 
 function M.init()
   local vendor_mago = vim.fn.findfile('vendor/bin/mago', '.;')
@@ -32,8 +95,15 @@ function M.run(cmd, opts)
 
   if result.stderr ~= '' then
     local err = vim.fn.trim(result.stderr)
-    local level = err:match '^(%S+)'
-    vim.notify('[mago.nvim] ' .. err, vim.log.levels[level] or vim.log.levels.ERROR)
+    if err ~= '' then
+      local level = parse_stderr_level(err)
+      if level >= M.config.logging.min_level then
+        if M.config.logging.notify then
+          vim.notify('[mago.nvim] ' .. err, level)
+        end
+        write_log(err, level)
+      end
+    end
   end
 
   return result.stdout

--- a/lua/mago-nvim/init.lua
+++ b/lua/mago-nvim/init.lua
@@ -1,7 +1,9 @@
 local M = {}
 
-function M.setup()
+function M.setup(opts)
+  opts = opts or {}
   local exe = require 'mago-nvim.executable'
+  exe.setup(opts)
   if not exe.init() then
     vim.notify('[mago.nvim] Mago executable not found', vim.log.levels.ERROR)
     return


### PR DESCRIPTION
I was getting annoyed by the notifications that had to be dismissed. This PR allows users to configure logging and notifications. Notifications also weren't allowing me to copy the messages (thx neovide), so I added writing to a log file as an alternative. I tested this with my other PR (#12 ) and it is quite pleasant to use now.

Should we consider changing the default configuration options to not use notify and to write to logs? It seems like a more sensible default to me