### PR TITLE
fix: don't run on unnamed buffer and enforce cwd

### DIFF
--- a/lua/mago-nvim/executable.lua
+++ b/lua/mago-nvim/executable.lua
@@ -10,6 +10,10 @@ M.config = {
   },
 }
 
+local function support()
+  return require 'mago-nvim.support'
+end
+
 local function normalize_level(level, fallback)
   if type(level) == 'number' then
     return level
@@ -87,6 +91,14 @@ function M.run(cmd, opts)
   if opts == nil then
     opts = {}
   end
+
+  local filepath = opts.filepath
+  opts.filepath = nil
+
+  if opts.cwd == nil and type(filepath) == 'string' and filepath ~= '' then
+    opts.cwd = support().cwd_from_filepath(filepath)
+  end
+
   table.insert(cmd, 1, M.mago_path)
 
   opts.text = true

--- a/lua/mago-nvim/run/fmt.lua
+++ b/lua/mago-nvim/run/fmt.lua
@@ -6,12 +6,17 @@ end
 
 function M.format_filepath(filepath)
   --
-  mago().run { 'fmt', filepath }
+  mago().run({ 'fmt', filepath }, {
+    filepath = filepath,
+  })
 end
 
-function M.format_stdin(input)
+function M.format_stdin(input, filepath)
   --
-  return mago().run({ 'fmt', '--stdin-input' }, { stdin = input })
+  return mago().run({ 'fmt', '--stdin-input' }, {
+    stdin = input,
+    filepath = filepath,
+  })
 end
 
 return M

--- a/lua/mago-nvim/run/lint.lua
+++ b/lua/mago-nvim/run/lint.lua
@@ -5,7 +5,9 @@ local function mago()
 end
 
 function M.check(filepath)
-  local output = mago().run { 'lint', '--reporting-format', 'json', filepath }
+  local output = mago().run({ 'lint', '--reporting-format', 'json', filepath }, {
+    filepath = filepath,
+  })
   if output == nil or output == '' then
     return {}
   end
@@ -14,7 +16,9 @@ function M.check(filepath)
 end
 
 function M.check_guard(filepath)
-  local output = mago().run { 'guard', '--reporting-format', 'json', filepath }
+  local output = mago().run({ 'guard', '--reporting-format', 'json', filepath }, {
+    filepath = filepath,
+  })
   if output == nil or output == '' then
     return {}
   end
@@ -35,15 +39,21 @@ function M.fix(filepath, rule)
     table.insert(cmd, rule)
   end
 
-  return mago().run(cmd)
+  return mago().run(cmd, {
+    filepath = filepath,
+  })
 end
 
-function M.list_files()
-  return mago().run { 'list-files', '--command', 'linter' }
+function M.list_files(filepath)
+  return mago().run({ 'list-files', '--command', 'linter' }, {
+    filepath = filepath,
+  })
 end
 
-function M.list_guard_files()
-  return mago().run { 'list-files', '--command', 'guard' }
+function M.list_guard_files(filepath)
+  return mago().run({ 'list-files', '--command', 'guard' }, {
+    filepath = filepath,
+  })
 end
 
 return M

--- a/lua/mago-nvim/server/code-actions.lua
+++ b/lua/mago-nvim/server/code-actions.lua
@@ -1,19 +1,29 @@
 local M = {}
 
+local function get_rule_code(diag)
+  return (diag.user_data and diag.user_data.lsp and diag.user_data.lsp.codeDescription)
+    or diag.codeDescription
+    or diag.code
+end
+
 local function get_issue(d)
   return {
     line = d.lnum + 1,
-    code = d.user_data.lsp.codeDescription,
+    code = get_rule_code(d),
   }
 end
 
 local function get_issues_from_buffer(bufnr)
   local contains_parse_issue = false
+
   local diagnostics = vim.tbl_filter(function(diag)
-    if diag.user_data.lsp.codeDescription == 'parse' then
+    local code = get_rule_code(diag)
+
+    if code == 'parse' then
       contains_parse_issue = true
     end
-    return diag.source == 'mago.nvim'
+
+    return diag.source == 'mago.nvim' and code ~= nil
   end, vim.diagnostic.get(bufnr))
 
   if contains_parse_issue == true then
@@ -21,7 +31,9 @@ local function get_issues_from_buffer(bufnr)
     return {}
   end
 
-  return vim.tbl_map(get_issue, diagnostics or {})
+  return vim.tbl_filter(function(issue)
+    return issue.code ~= nil
+  end, vim.tbl_map(get_issue, diagnostics or {}))
 end
 
 local function issues_to_list(issues)

--- a/lua/mago-nvim/server/diagnostics.lua
+++ b/lua/mago-nvim/server/diagnostics.lua
@@ -39,10 +39,15 @@ local function get_diagnostics_from_mago_issues(issues, bufnr)
 end
 
 local function uri_can_be_checked(uri)
+  local filepath = vim.uri_to_fname(uri)
+  if type(filepath) ~= 'string' or filepath == '' then
+    return false
+  end
+
   local relative_filepath = require('mago-nvim.support').uri_to_relative_fname(uri)
   local lint = require 'mago-nvim.run.lint'
-  local lint_files = vim.split(lint.list_files(), '\n')
-  local guard_files = vim.split(lint.list_guard_files(), '\n')
+  local lint_files = vim.split(lint.list_files(filepath), '\n')
+  local guard_files = vim.split(lint.list_guard_files(filepath), '\n')
 
   return vim.tbl_contains(lint_files, relative_filepath) or vim.tbl_contains(guard_files, relative_filepath)
 end

--- a/lua/mago-nvim/server/format.lua
+++ b/lua/mago-nvim/server/format.lua
@@ -17,7 +17,7 @@ function M.format_uri(uri)
   local old_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local input = table.concat(old_lines, '\n')
 
-  local output = fmt.format_stdin(input)
+  local output = fmt.format_stdin(input, filepath)
   if output == '' then
     return
   end

--- a/lua/mago-nvim/server/init.lua
+++ b/lua/mago-nvim/server/init.lua
@@ -85,7 +85,15 @@ local function create_server(dispatchers)
 end
 
 local function start_mago(bufnr)
+  if vim.api.nvim_buf_get_name(bufnr) == '' then
+    return
+  end
+
   vim.schedule(function()
+    if vim.api.nvim_buf_get_name(bufnr) == '' then
+      return
+    end
+
     vim.lsp.start({
       name = 'mago.nvim',
       cmd = create_server,

--- a/lua/mago-nvim/support.lua
+++ b/lua/mago-nvim/support.lua
@@ -1,11 +1,35 @@
 local M = {}
 
+function M.cwd_from_filepath(filepath)
+  if type(filepath) ~= 'string' or filepath == '' then
+    return vim.fn.getcwd()
+  end
+
+  local absolute = vim.fn.fnamemodify(filepath, ':p')
+  local root = vim.fs.root(absolute, { '.git', 'composer.json' })
+
+  if root and root ~= '' then
+    return root
+  end
+
+  return vim.fn.fnamemodify(absolute, ':h')
+end
+
 function M.uri_to_relative_fname(uri)
   local fname = vim.uri_to_fname(uri)
-  local root = vim.fs.root(0, { '.git', 'composer.json' }) or vim.fn.getcwd()
-  local relative = vim.fn.fnamemodify(fname, ':p'):sub(#root + 2)
+  if type(fname) ~= 'string' or fname == '' then
+    return ''
+  end
 
-  return relative
+  local absolute = vim.fn.fnamemodify(fname, ':p')
+  local root = M.cwd_from_filepath(absolute)
+  local prefix = root .. '/'
+
+  if absolute:sub(1, #prefix) == prefix then
+    return absolute:sub(#prefix + 1)
+  end
+
+  return vim.fn.fnamemodify(absolute, ':t')
 end
 
 return M


### PR DESCRIPTION
I had some issues where if I opened a PHP buffer from a floating neo-tree, mago would run away and consume all of my memory. This PR fixes the issue by enforcing a valid cwd and preventing it from starting on a unnamed buffer.